### PR TITLE
Configurable token length

### DIFF
--- a/drfpasswordless/models.py
+++ b/drfpasswordless/models.py
@@ -3,6 +3,8 @@ from django.db import models
 from django.conf import settings
 import string
 from django.utils.crypto import get_random_string
+from drfpasswordless.settings import api_settings
+
 
 def generate_hex_token():
     return uuid.uuid1().hex
@@ -13,7 +15,7 @@ def generate_numeric_token():
     Generate a random 6 digit string of numbers.
     We use this formatting to allow leading 0s.
     """
-    return get_random_string(length=6, allowed_chars=string.digits)
+    return get_random_string(length=api_settings.PASSWORDLESS_TOKEN_LENGTH, allowed_chars=string.digits)
 
 
 class CallbackTokenManger(models.Manager):

--- a/drfpasswordless/serializers.py
+++ b/drfpasswordless/serializers.py
@@ -175,7 +175,7 @@ class AbstractBaseCallbackTokenSerializer(serializers.Serializer):
 
     email = serializers.EmailField(required=False)  # Needs to be required=false to require both.
     mobile = serializers.CharField(required=False, validators=[phone_regex], max_length=15)
-    token = TokenField(min_length=6, max_length=6, validators=[token_age_validator])
+    token = TokenField(min_length=api_settings.PASSWORDLESS_TOKEN_LENGTH, max_length=api_settings.PASSWORDLESS_TOKEN_LENGTH, validators=[token_age_validator])
 
     def validate_alias(self, attrs):
         email = attrs.get('email', None)

--- a/drfpasswordless/settings.py
+++ b/drfpasswordless/settings.py
@@ -17,6 +17,9 @@ DEFAULTS = {
     # Amount of time that tokens last, in seconds
     'PASSWORDLESS_TOKEN_EXPIRE_TIME': 15 * 60,
 
+    # The length of the token to send in email or sms
+    'PASSWORDLESS_TOKEN_LENGTH': 6,
+
     # The user's email field name
     'PASSWORDLESS_USER_EMAIL_FIELD_NAME': 'email',
 


### PR DESCRIPTION
The sent token was 6 digit long with fixed value. This commit contains the neccessary changes to be able to configure as we want.